### PR TITLE
Fix BundleAdjustmentModels.jl: Start the tutorial with a sentence

### DIFF
--- a/tutorials/introduction-to-bundleadjustmentmodels/index.jmd
+++ b/tutorials/introduction-to-bundleadjustmentmodels/index.jmd
@@ -4,11 +4,11 @@ tags: ["introduction", "model", "least-squares", "nlsmodels", "test set", "bundl
 author: "Antonin Kenens and Tangi Migot"
 ---
 
+A Julia repository of [bundle adjustment](https://en.wikipedia.org/wiki/Bundle_adjustment) problems from the [Bundle Adjustment in the Large](http://grail.cs.washington.edu/projects/bal/) repository.
+
 ```julia
 using BundleAdjustmentModels
 ```
-
-This package is a Julia repository of [bundle adjustment](https://en.wikipedia.org/wiki/Bundle_adjustment) problems from the [Bundle Adjustment in the Large](http://grail.cs.washington.edu/projects/bal/) repository.
 
 ## Get the list of problems
 


### PR DESCRIPTION
The tutorial doesn't show on the website https://juliasmoothoptimizers.github.io/tutorials/ even though the page exists https://juliasmoothoptimizers.github.io/tutorials/introduction-to-bundleadjustmentmodels/ .
I am suspecting this would fix it