### PR TITLE
Update `solver_specific` example due to failure

### DIFF
--- a/tutorials/introduction-to-solverbenchmark/Project.toml
+++ b/tutorials/introduction-to-solverbenchmark/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 NLPModelsTest = "7998695d-6960-4d3a-85c4-e1bceb8cd856"
+NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
@@ -12,6 +13,7 @@ SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 
 DataFrames = "1.3.4"
 NLPModelsTest = "0.9"
+NLPModels = "0.20"
 Plots = "1.31.7"
 PyPlot = "2.10.0"
 SolverBenchmark = "0.5.3"

--- a/tutorials/introduction-to-solverbenchmark/index.jmd
+++ b/tutorials/introduction-to-solverbenchmark/index.jmd
@@ -224,16 +224,22 @@ The tutorial covers how to use the problems from `OptimizationProblems` to run a
 
 ### Handling `solver_specific` in `stats`
 
-If a solver's `GenericExecutionStats` contains a `solver_specific` dictionary, then when `bmark_solvers` processes the results it creates a column in the per-solver `DataFrame` for each key in that dictionary. These columns can then be analyzed and compared alongside the standard metrics such as `status` and `elapsed_time`.
+If a solver's `GenericExecutionStats` contains a `solver_specific` dictionary, those values can be tabulated alongside the standard metrics such as `status` and `elapsed_time`.
 
-Here is an example showing how to set a solver-specific flag so that it appears as a column in the resulting stats table and can be used for tabulation:
+Here is an example showing how to populate `solver_specific` and place those fields in a stats table:
 ```julia
-using ADNLPModels, SolverCore
+using ADNLPModels, DataFrames, SolverCore
 
 nlp = ADNLPModel(x -> sum(x .^ 2), [1.0, 1.0])
-stats = GenericExecutionStats(nlp)
-set_solver_specific!(stats, :isConvex, true)
-set_solver_specific!(stats, :inner_iterations, 7)
+stats = SolverCore.GenericExecutionStats(nlp)
+SolverCore.set_solver_specific!(stats, :isConvex, true)
+SolverCore.set_solver_specific!(stats, :inner_iterations, 7)
 
-stats.solver_specific
+df = DataFrame(
+  solver = ["newton"],
+  status = [stats.status],
+  isConvex = [stats.solver_specific[:isConvex]],
+  inner_iterations = [stats.solver_specific[:inner_iterations]],
+)
+pretty_stats(stdout, df)
 ```

--- a/tutorials/introduction-to-solverbenchmark/index.jmd
+++ b/tutorials/introduction-to-solverbenchmark/index.jmd
@@ -224,9 +224,9 @@ The tutorial covers how to use the problems from `OptimizationProblems` to run a
 
 ### Handling `solver_specific` in `stats`
 
-If a solver's `GenericExecutionStats` contains a `solver_specific` dictionary, those values can be tabulated alongside the standard metrics such as `status` and `elapsed_time`.
+If a solver's `GenericExecutionStats` contains a `solver_specific` dictionary, then when `bmark_solvers` processes the results it creates a column in the per-solver `DataFrame` for each key in that dictionary. These columns can then be analyzed and compared alongside the standard metrics such as `status` and `elapsed_time`.
 
-Here is an example showing how to populate `solver_specific` and place those fields in a stats table:
+Here is an example showing how to set a solver-specific flag so that it appears as a column in the resulting stats table and can be used for tabulation:
 ```julia
 import NLPModels: reset!
 using NLPModelsTest, DataFrames, SolverCore, SolverBenchmark

--- a/tutorials/introduction-to-solverbenchmark/index.jmd
+++ b/tutorials/introduction-to-solverbenchmark/index.jmd
@@ -228,19 +228,12 @@ If a solver's `GenericExecutionStats` contains a `solver_specific` dictionary, t
 
 Here is an example showing how to set a solver-specific flag so that it appears as a column in the resulting stats table and can be used for tabulation:
 ```julia
-using NLPModelsTest, DataFrames, SolverCore, SolverBenchmark
+using ADNLPModels, SolverCore
 
-function newton(nlp)
-  stats = GenericExecutionStats(nlp)
-  set_solver_specific!(stats, :isConvex, true)
-  return stats
-end
+nlp = ADNLPModel(x -> sum(x .^ 2), [1.0, 1.0])
+stats = GenericExecutionStats(nlp)
+set_solver_specific!(stats, :isConvex, true)
+set_solver_specific!(stats, :inner_iterations, 7)
 
-solvers = Dict(:newton => newton)
-problems = [NLPModelsTest.BROWNDEN()]
-stats = bmark_solvers(solvers, problems)
-
-# Access the solver-specific column `:isConvex` for the `:newton` solver
-df_newton = stats[:newton]
-df_newton.isConvex
+stats.solver_specific
 ```

--- a/tutorials/introduction-to-solverbenchmark/index.jmd
+++ b/tutorials/introduction-to-solverbenchmark/index.jmd
@@ -228,18 +228,20 @@ If a solver's `GenericExecutionStats` contains a `solver_specific` dictionary, t
 
 Here is an example showing how to populate `solver_specific` and place those fields in a stats table:
 ```julia
-using ADNLPModels, DataFrames, SolverCore
+import NLPModels: reset!
+using NLPModelsTest, DataFrames, SolverCore, SolverBenchmark
 
-nlp = ADNLPModel(x -> sum(x .^ 2), [1.0, 1.0])
-stats = SolverCore.GenericExecutionStats(nlp)
-SolverCore.set_solver_specific!(stats, :isConvex, true)
-SolverCore.set_solver_specific!(stats, :inner_iterations, 7)
+function newton(nlp)
+  stats = GenericExecutionStats(nlp)
+  set_solver_specific!(stats, :isConvex, true)
+  return stats
+end
 
-df = DataFrame(
-  solver = ["newton"],
-  status = [stats.status],
-  isConvex = [stats.solver_specific[:isConvex]],
-  inner_iterations = [stats.solver_specific[:inner_iterations]],
-)
-pretty_stats(stdout, df)
+solvers = Dict(:newton => newton)
+problems = [NLPModelsTest.BROWNDEN()]
+stats = bmark_solvers(solvers, problems)
+
+# Access the solver-specific column `:isConvex` for the `:newton` solver
+df_newton = stats[:newton]
+df_newton.isConvex
 ```


### PR DESCRIPTION
@tmigot The rendering failure was caused by the newly added example in the solver_specific section: calling bmark_solvers in this environment triggers `UndefVarError: reset!` during weaving, which then broke the generated page content. I reproduced this locally from the same weave/parse pipeline and confirmed the failing error block in `index.md:560`
